### PR TITLE
Rearrange projects and show projects in CV instead of working experience

### DIFF
--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -94,9 +94,6 @@ const imageResult = imageMetadata.map((projectMediaMetadata) =>
 const featuredProjects: Project[] = []
 const otherProjects: Project[] = []
 
-/**
- * For me open source contributions are much more important
- */
 for (let projectId = 0; projectId < projects.length; projectId++) {
     const project = projects[projectId]
     if (!project) {
@@ -125,9 +122,9 @@ for (let projectId = 0; projectId < projects.length; projectId++) {
         contributorRegexp.test(project.name) ||
         contributorRegexp.test(project.summary!)
     ) {
-        featuredProjects.push({ ...project, technologies, images })
-    } else {
         otherProjects.push({ ...project, technologies, images })
+    } else {
+        featuredProjects.push({ ...project, technologies, images })
     }
 }
 
@@ -230,6 +227,42 @@ const isCV = isCVMode()
                 {
                     otherProjects.map((project) => (
                         <Card class="group hover-scale transition-all duration-300">
+                            {project.images.length > 0 && !isCV && (
+                                <div>
+                                    <Carousel
+                                        imgs={project.images.map(
+                                            (image, imageIndex) => {
+                                                const carouselImage: CarouselImage =
+                                                    {
+                                                        srcset: image.srcSet
+                                                            .attribute,
+                                                        src: image.src,
+                                                        loading:
+                                                            imageIndex === 0
+                                                                ? 'eager'
+                                                                : 'lazy',
+                                                    }
+                                                const label =
+                                                    project.media[imageIndex]
+                                                        ?.name
+                                                const link =
+                                                    project.media[imageIndex]
+                                                        ?.url
+
+                                                if (label) {
+                                                    carouselImage.label = label
+                                                }
+
+                                                if (link) {
+                                                    carouselImage.link = link
+                                                }
+
+                                                return carouselImage
+                                            }
+                                        )}
+                                    />
+                                </div>
+                            )}
                             <CardHeader>
                                 <div class="flex items-center gap-2 mb-2">
                                     <Folder class="text-primary" size={18} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,8 +76,8 @@ const htmlClassList = import.meta.env.CV === 'dark' ? ['dark'] : []
             {!isCV && <Navigation />}
             <main>
                 <HeroSection />
-                <ResumeSection />
-                {!isCV && <ProjectsSection />}
+                {!isCV && <ResumeSection />}
+                <ProjectsSection />
                 <ContactSection />
             </main>
 


### PR DESCRIPTION
This pull request includes changes to the `ProjectsSection` and `index.astro` files to improve the organization of featured projects, enhance the display of project images, and adjust the rendering order of sections on the main page. Below are the most significant changes grouped by theme:

### Improvements to project categorization and display:

* Fixed the logic for categorizing projects into `featuredProjects` and `otherProjects` by swapping the conditional branches, ensuring the correct projects are added to the appropriate lists. (`src/components/ProjectsSection.astro`, [src/components/ProjectsSection.astroL128-R127](diffhunk://#diff-5f33280c75fe33ad8b0e5d490b6c0eacfc79d2b2505d61a297c87833833850f2L128-R127))
* Added a carousel component to display project images for non-CV mode, enhancing the visual presentation of projects. The carousel includes image labels and links when available. (`src/components/ProjectsSection.astro`, [src/components/ProjectsSection.astroR230-R265](diffhunk://#diff-5f33280c75fe33ad8b0e5d490b6c0eacfc79d2b2505d61a297c87833833850f2R230-R265))

### Code cleanup:

* Removed an outdated comment that was no longer relevant to the code. (`src/components/ProjectsSection.astro`, [src/components/ProjectsSection.astroL97-L99](diffhunk://#diff-5f33280c75fe33ad8b0e5d490b6c0eacfc79d2b2505d61a297c87833833850f2L97-L99))

### Adjustments to section rendering:

* Changed the rendering order of the `ResumeSection` and `ProjectsSection` components on the main page to improve the layout. (`src/pages/index.astro`, [src/pages/index.astroL79-R80](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L79-R80))